### PR TITLE
Use safer and idempotent `newPlot` instead of `plot`

### DIFF
--- a/js/src/Figure.js
+++ b/js/src/Figure.js
@@ -540,7 +540,7 @@ var FigureView = widgets.DOMWidgetView.extend({
         var initial_traces = JSON.parse(JSON.stringify(this.model.get('_data')));
         var initial_layout = JSON.parse(JSON.stringify(this.model.get('_layout')));
 
-        Plotly.plot(this.el, initial_traces, initial_layout).then(function () {
+        Plotly.newPlot(this.el, initial_traces, initial_layout).then(function () {
 
             // Update layout
             var relayoutDelta = that.create_delta_object(that.model.get('_layout'), that.getFullLayout());


### PR DESCRIPTION
`newPlot` can safely be called multiple times on the same element whereas `plot` sometimes can't be. The existing use of `plot` might explain why https://github.com/jmmease/ipyplotly/commit/e310d2bf897a98366f1ed35b9a5caf830784ad6b was necessary.